### PR TITLE
Auto-discovery of OpenGL libraries

### DIFF
--- a/lib/mittsu/renderers/opengl/opengl_debug.rb
+++ b/lib/mittsu/renderers/opengl/opengl_debug.rb
@@ -31,8 +31,8 @@ module OpenGLDebug
     extend OpenGL
   end
 
-  def self.load_lib
-    OpenGL.load_lib
+  def self.load_lib(*args)
+    OpenGL.load_lib(*args)
   end
 
   OpenGL.constants.each do |c|

--- a/lib/mittsu/renderers/opengl/opengl_lib.rb
+++ b/lib/mittsu/renderers/opengl/opengl_lib.rb
@@ -1,0 +1,62 @@
+module OpenGLLib
+  def self.discover
+    case OpenGL.get_platform
+    when :OPENGL_PLATFORM_WINDOWS
+      Windows.new
+    when :OPENGL_PLATFORM_MACOSX
+      MacOS.new
+    when :OPENGL_PLATFORM_LINUX
+      Linux.new
+    else
+      fail "Unsupported platform."
+    end
+  end
+
+  class Linux
+    def path
+      # http://www.pilotlogic.com/sitejoom/index.php/wiki?id=398<F37>
+      # 32              64
+      # /usr/lib        /usr/lib64       redhat, mandriva
+      # /usr/lib32      /usr/lib64       arch, gento
+      # /usr/lib        /usr/lib64       slackware
+      # /usr/lib/i386.. /usr/libx86_64/  debian
+      libs = Dir.glob("/usr/lib*/**/libGL.so")
+      if libs.size == 0
+        puts "no libGL.so"
+        exit 1
+      end
+      case kernel_module_in_use
+      when /nvidia/
+        return File.dirname(libs.grep(/nvidia/)[0])
+      end
+      # Get the same architecture that the runnning ruby
+      if 1.size == 8 # 64 bits
+        File.dirname(libs.grep(/64/)[0])
+      else # 32 bits
+        File.dirname(libs[0])
+      end
+    end
+
+    def file
+      'libGL.so'
+    end
+
+    private
+      def kernel_module_in_use
+        lspci_line = `lspci -nnk | grep -i vga -A3 | grep 'in use'`
+        return /in use:\s*(\S+)/ =~ lspci_line && $1
+      end
+  end
+
+  # TODO
+  def Windows
+    def path; nil; end
+    def file; nil; end
+  end
+
+  # TODO
+  def MacOS
+    def path; nil; end
+    def file; nil; end
+  end
+end

--- a/lib/mittsu/renderers/opengl_renderer.rb
+++ b/lib/mittsu/renderers/opengl_renderer.rb
@@ -2,7 +2,10 @@ require 'opengl'
 require 'glfw'
 require 'fiddle'
 
-OpenGL.load_lib
+
+require 'mittsu/renderers/opengl/opengl_lib'
+opengl_lib = OpenGLLib.discover
+OpenGL.load_lib(opengl_lib.file, opengl_lib.path)
 
 require 'mittsu'
 require 'mittsu/renderers/glfw_window'

--- a/test/support/opengl_stub.rb
+++ b/test/support/opengl_stub.rb
@@ -1,7 +1,14 @@
 require 'opengl'
+require 'mittsu/renderers/opengl/opengl_lib'
+
+module OpenGLLib
+  def self.discover
+    Struct.new(:path, :file).new(nil, nil)
+  end
+end
 
 module OpenGLStub
-  def self.load_lib
+  def self.load_lib(*args)
   end
 
   OpenGL.constants.each do |c|


### PR DESCRIPTION
By default the `opengl-bindings` gem does not "discover" the location of OpenGL libraries. While this is not a problem in some systems, this may cause errors in others.

For example, on my 64-bit Ubuntu 16.04 with the `nvidia-361` package installed.

My approach to fixing this problem is to read which video driver kernel module is in use, and then search for a libGL.so file in a directory corresponding with the driver.

I will need some other test systems to discover where these drivers may be on various architectures, distros, and video driver combinations.

I am also going to add an environment variable to override the opengl lib directory for people with exceptional situations.