### PR TITLE
Fix wireframe rendering (with MeshBasicMaterial)

### DIFF
--- a/lib/mittsu/materials/mesh_basic_material.rb
+++ b/lib/mittsu/materials/mesh_basic_material.rb
@@ -33,9 +33,10 @@ require 'mittsu/materials/material'
 #  fog: <bool>
 # }
 module Mittsu
-  attr_accessor :color, :map, :light_map, :specular_map, :alpha_map, :env_map, :combine, :reflectivity, :refraction_ratio, :shading, :wireframe, :wireframe_linewidth, :wireframe_linecap, :wireframe_linejoin, :vertex_colors, :skinning, :morph_targets, :fog
-
   class MeshBasicMaterial < Material
+
+    attr_accessor :color, :map, :light_map, :specular_map, :alpha_map, :env_map, :combine, :reflectivity, :refraction_ratio, :shading, :wireframe, :wireframe_linewidth, :wireframe_linecap, :wireframe_linejoin, :vertex_colors, :skinning, :morph_targets, :fog
+
     def initialize(parameters = {})
       super()
 

--- a/lib/mittsu/renderers/opengl/objects/mesh.rb
+++ b/lib/mittsu/renderers/opengl/objects/mesh.rb
@@ -7,7 +7,7 @@ module Mittsu
 
       # wireframe
       if material.wireframe
-        @renderer.state.set_line_width(material.wireframe_linewidth * @pixel_ratio)
+        @renderer.state.set_line_width(material.wireframe_linewidth * @renderer.pixel_ratio)
 
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, geometry_group.line_buffer) if update_buffers
         glDrawElements(GL_LINES, geometry_group.line_count, type, 0)


### PR DESCRIPTION
This patches two classes to allow a simple `MeshBasicMaterial.new{wireframe:true}` to render without crashing.

Changes MeshBasicMaterial to include the correct accessors (required for `wireframe_linewidth`), and corrects `@renderer.pixel_ratio` inside the Mesh#render_buffer method.

All line widths seem to be the same on my system; not sure if that's supposed to be the case or not, but it does render now.