### PR TITLE
fixed two errors with the Mittsu::MeshFaceMaterial

### DIFF
--- a/lib/mittsu/materials/mesh_face_material.rb
+++ b/lib/mittsu/materials/mesh_face_material.rb
@@ -2,6 +2,8 @@ require 'securerandom'
 
 module Mittsu
   class MeshFaceMaterial
+    attr_reader :materials
+
     def initialize(materials = [])
       @uuid = SecureRandom.uuid
       @type = 'MeshFaceMaterial'

--- a/lib/mittsu/renderers/opengl/opengl_geometry_group.rb
+++ b/lib/mittsu/renderers/opengl/opengl_geometry_group.rb
@@ -4,7 +4,7 @@ module Mittsu
   class OpenGLGeometryGroup
     include OpenGLGeometryLike
 
-    attr_reader :id
+    attr_reader :id, :material_index
 
     alias :initted_arrays? :initted_arrays
 

--- a/test/sanity/test_mesh_face_sanity_check.rb
+++ b/test/sanity/test_mesh_face_sanity_check.rb
@@ -1,0 +1,30 @@
+require 'minitest_helper'
+
+class TestMeshFaceSanityCheck < Minitest::Test
+  def test_that_it_works
+    scene = Mittsu::Scene.new
+    camera = Mittsu::PerspectiveCamera.new(75.0, 1.0, 0.1, 1000.0)
+
+    renderer = Mittsu::OpenGLRenderer.new width: 100, height: 100, title: 'TestMeshFaceSanityCheck'
+
+    geometry = Mittsu::BoxGeometry.new(1.0, 1.0, 1.0)
+    material = Mittsu::MeshFaceMaterial.new([
+      Mittsu::MeshBasicMaterial.new(color: 0x0046AD), # blue
+      Mittsu::MeshBasicMaterial.new(color: 0x009B48), # green
+      Mittsu::MeshBasicMaterial.new(color: 0xFFFFFF), # white
+      Mittsu::MeshBasicMaterial.new(color: 0xFFD500), # yellow
+      Mittsu::MeshBasicMaterial.new(color: 0xF55500), # orange
+      Mittsu::MeshBasicMaterial.new(color: 0xB71234), # red
+    ])
+    cube = Mittsu::Mesh.new(geometry, material)
+    scene.add(cube)
+
+    camera.position.z = 5.0
+
+    renderer.window.run do
+      cube.rotation.x += 0.1
+      cube.rotation.y += 0.1
+      renderer.render(scene, camera)
+    end
+  end
+end


### PR DESCRIPTION
I've found to errors whilst using the `Mittsu::MeshFaceMaterial` in a `Mittsu::Mesh`.

In [lib/mittsu/renderers/opengl/core/object_3d.rb:105](https://github.com/jellymann/mittsu/blob/bbb39739c90b122003927c7e3bf4d929a0f1bfcb/lib/mittsu/renderers/opengl/core/object_3d.rb#L105) there is a reference to `MeshFaceMaterial#materials` and `OpenGLGeometryGroup#material_index` which both are only instance variables without a getter.

I've tried to get the testing to run, to implement a test for that. Unfortunately I only get the error `Unsupported platform.` The Platform seems to be `:OPENGL_PLATFORM_TEST`