### PR TITLE
Fix: unsupported platform error on Travis

### DIFF
--- a/lib/mittsu/renderers/generic_lib.rb
+++ b/lib/mittsu/renderers/generic_lib.rb
@@ -9,11 +9,17 @@ module Mittsu
       when :OPENGL_PLATFORM_LINUX
         self::Linux.new
       else
-        fail "Unsupported platform."
+        warn "WARNING: Unsupported platform: #{OpenGL.get_platform}"
+        self::Base.new
       end
     end
 
-    class Linux
+    class Base
+      def path; nil; end
+      def file; nil; end
+    end
+
+    class Linux < Base
       def path
         return nil if file_path.nil?
         File.dirname file_path

--- a/lib/mittsu/renderers/generic_lib.rb
+++ b/lib/mittsu/renderers/generic_lib.rb
@@ -10,7 +10,7 @@ module Mittsu
         self::Linux.new
       else
         warn "WARNING: Unsupported platform: #{OpenGL.get_platform}"
-        self::Base.new
+        Base.new
       end
     end
 

--- a/lib/mittsu/renderers/glfw_lib.rb
+++ b/lib/mittsu/renderers/glfw_lib.rb
@@ -24,12 +24,10 @@ module Mittsu
       end
     end
 
-    class Windows
-      def path; nil; end
-      def file; nil; end
+    class Windows < GenericLib::Base
     end
 
-    class MacOS
+    class MacOS < GenericLib::Base
       def path
         '/usr/local/lib'
       end

--- a/lib/mittsu/renderers/opengl/opengl_lib.rb
+++ b/lib/mittsu/renderers/opengl/opengl_lib.rb
@@ -10,14 +10,10 @@ module Mittsu
       end
     end
 
-    class Windows
-      def path; nil; end
-      def file; nil; end
+    class Windows < GenericLib::Base
     end
 
-    class MacOS
-      def path; nil; end
-      def file; nil; end
+    class MacOS < GenericLib::Base
     end
   end
 end


### PR DESCRIPTION
Recently something changed on Travis and builds started failing with "Unsupported Platform". Not sure why this started happening, or why it hasn't happened in the past. The reason for it is because while testing, the platform is stubbed out as OPENGL_PLATFORM_TEST since the actual OpenGL function calls are completely stubbed out and are therefore platform independent.

I've changed this failure to a warning and fall back to a generic library loader in this case.