### PR TITLE
fix: glfw lib loading on macos

### DIFF
--- a/lib/mittsu/renderers/glfw_lib.rb
+++ b/lib/mittsu/renderers/glfw_lib.rb
@@ -34,7 +34,7 @@ module Mittsu
 
       def file
         matches = Dir.glob('/usr/local/lib/libglfw*.dylib').map { |path| File.basename(path) }
-        return matches.find('libglfw3.dylib') || matches.find('libglfw.3.dylib') || matches.first
+        return matches.find { |m| m == 'libglfw3.dylib' || m == 'libglfw.3.dylib' } || matches.first
       end
     end
   end


### PR DESCRIPTION
Fixes an issue where the following error occurs on macos when loading libglfw:

```
no implicit conversion of Enumerator into String (TypeError)
```