### PR TITLE
Fix filter variable

### DIFF
--- a/lib/mittsu/renderers/opengl/textures/texture.rb
+++ b/lib/mittsu/renderers/opengl/textures/texture.rb
@@ -77,7 +77,7 @@ module Mittsu
 
   	# Fallback filters for non-power-of-2 textures
   	def filter_fallback(filter)
-  		if filter == NearestFilter || filter == NearestMipMapNearestFilter || f == NearestMipMapLinearFilter
+  		if filter == NearestFilter || filter == NearestMipMapNearestFilter || filter == NearestMipMapLinearFilter
   			GL_NEAREST
   		end
 


### PR DESCRIPTION
In this PR I rename the `f` variable to `filter` in the `filter_fallback` method. Possibly this was the remnant of refactoring.