### PR TITLE
Support recent Ruby versions; clearing up warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: ruby
+rvm:
+  - 2.3.8
+  - 2.4.5
+  - 2.5.5
+  - 2.6.2
+before_install:
+  - sudo apt-get update; sudo apt-get install libglfw3 -y
+  - gem install bundler
+  - gem update --system
+script:
+  - bundle exec rake test

--- a/Rakefile
+++ b/Rakefile
@@ -4,4 +4,5 @@ require 'rake/testtask'
 Rake::TestTask.new do |t|
   t.libs << "test"
   t.pattern = "test/**/test_*.rb"
+  t.warning = false
 end

--- a/lib/mittsu.rb
+++ b/lib/mittsu.rb
@@ -1,19 +1,4 @@
-module Mittsu
-  DEBUG = ENV["DEBUG"] == "true"
-
-  def self.debug?
-    DEBUG
-  end
-
-  def self.env
-    ENV["MITTSU_ENV"]
-  end
-
-  def self.test?
-    env == 'test'
-  end
-end
-
+require "mittsu/utils"
 require "mittsu/version"
 require "mittsu/math"
 require "mittsu/core"

--- a/lib/mittsu/cameras/camera.rb
+++ b/lib/mittsu/cameras/camera.rb
@@ -1,5 +1,3 @@
-require 'mittsu'
-
 module Mittsu
   class Camera < Object3D
     attr_accessor :projection_matrix, :matrix_world_inverse

--- a/lib/mittsu/cameras/cube_camera.rb
+++ b/lib/mittsu/cameras/cube_camera.rb
@@ -1,5 +1,3 @@
-require 'mittsu'
-
 module Mittsu
   class CubeCamera < Object3D
     attr_accessor :render_target

--- a/lib/mittsu/cameras/orthographic_camera.rb
+++ b/lib/mittsu/cameras/orthographic_camera.rb
@@ -1,5 +1,3 @@
-require 'mittsu'
-
 module Mittsu
   class OrthographicCamera < Camera
     attr_accessor :zoom, :left, :right, :top, :bottom, :near, :far

--- a/lib/mittsu/cameras/perspective_camera.rb
+++ b/lib/mittsu/cameras/perspective_camera.rb
@@ -13,6 +13,7 @@ module Mittsu
       @aspect = aspect.to_f
       @near = near.to_f
       @far = far.to_f
+      @full_width = nil
 
       update_projection_matrix
     end

--- a/lib/mittsu/cameras/perspective_camera.rb
+++ b/lib/mittsu/cameras/perspective_camera.rb
@@ -1,5 +1,3 @@
-require 'mittsu'
-
 module Mittsu
   class PerspectiveCamera < Camera
     attr_accessor :zoom, :fov, :aspect, :near, :far

--- a/lib/mittsu/core/buffer_geometry.rb
+++ b/lib/mittsu/core/buffer_geometry.rb
@@ -20,6 +20,7 @@ module Mittsu
       @attributes = {}
 
       @draw_calls = []
+      @_listeners = {}
     end
 
     def keys

--- a/lib/mittsu/core/buffer_geometry.rb
+++ b/lib/mittsu/core/buffer_geometry.rb
@@ -1,5 +1,4 @@
 require 'securerandom'
-require 'mittsu'
 require 'mittsu/core/event_dispatcher'
 
 module Mittsu

--- a/lib/mittsu/core/geometry.rb
+++ b/lib/mittsu/core/geometry.rb
@@ -50,6 +50,8 @@ module Mittsu
       @colors_need_update = false
       @line_distances_need_update = false
       @groups_need_update = false
+
+      @_listeners = {}
     end
 
     def apply_matrix(matrix)
@@ -427,12 +429,10 @@ module Mittsu
         face.b = changes[face.b]
         face.c = changes[face.c]
         indices = [face.a, face.b, face.c]
-        dup_index = -1
         # if any duplicate vertices are found in a Face3
         # we have to remove the face as nothing can be saved
         3.times do |n|
           if indices[n] == indices[(n + 1) % 3]
-            dup_index = n
             face_indices_to_remove << i
             break
           end

--- a/lib/mittsu/core/geometry.rb
+++ b/lib/mittsu/core/geometry.rb
@@ -1,6 +1,4 @@
 require 'securerandom'
-require 'mittsu'
-require 'securerandom'
 
 module Mittsu
   class Geometry

--- a/lib/mittsu/core/object_3d.rb
+++ b/lib/mittsu/core/object_3d.rb
@@ -1,5 +1,4 @@
 require 'securerandom'
-require 'mittsu'
 
 module Mittsu
   class Object3D
@@ -22,6 +21,7 @@ module Mittsu
       @type = 'Object3D'
 
       @children = []
+      @parent = nil
 
       @up = DefaultUp.clone
 

--- a/lib/mittsu/core/object_3d.rb
+++ b/lib/mittsu/core/object_3d.rb
@@ -22,6 +22,7 @@ module Mittsu
 
       @children = []
       @parent = nil
+      @name = nil
 
       @up = DefaultUp.clone
 
@@ -55,6 +56,7 @@ module Mittsu
       @render_order = 0
 
       @user_data = {}
+      @_listeners = {}
     end
 
     def name

--- a/lib/mittsu/core/raycaster.rb
+++ b/lib/mittsu/core/raycaster.rb
@@ -1,5 +1,3 @@
-require 'mittsu'
-
 module Mittsu
   class Raycaster
     attr_accessor :near, :far, :ray, :params, :precision

--- a/lib/mittsu/loaders/obj_loader.rb
+++ b/lib/mittsu/loaders/obj_loader.rb
@@ -23,6 +23,10 @@ module Mittsu
 
     def initialize(manager = DefaultLoadingManager)
       @manager = manager
+      @object = nil
+      @mesh = nil
+      @material = nil
+      @_listeners = {}
     end
 
     def load(url)

--- a/lib/mittsu/materials/material.rb
+++ b/lib/mittsu/materials/material.rb
@@ -6,9 +6,13 @@ module Mittsu
 
     attr_reader :id, :uuid, :type
 
-    attr_accessor :name, :side, :opacity, :transparent, :blending, :blend_src, :blend_dst, :blend_equation, :blend_src_alpha, :blend_dst_alpha, :blend_equation_alpha, :depth_test, :depth_write, :color_write, :polygon_offset, :polygon_offset_factor, :polygon_offset_units, :alpha_test, :overdraw, :visible, :attributes, :shading, :program
+    attr_accessor :name, :side, :opacity, :transparent, :blending, :blend_src, :blend_dst, :blend_equation, :blend_src_alpha,
+      :blend_dst_alpha, :blend_equation_alpha, :depth_test, :depth_write, :color_write, :polygon_offset, :polygon_offset_factor,
+      :polygon_offset_units, :alpha_test, :overdraw, :visible, :attributes, :shading, :program
 
-    attr_accessor :map, :env_map, :light_map, :light_map, :normal_map, :specular_map, :alpha_map, :combine, :vertex_colors, :fog, :size_attenuation, :skinning, :morph_targets, :morph_normals, :metal, :wrap_around, :defines, :lights, :color, :bump_map, :reflectivity, :refraction_ratio, :wireframe, :default_attribute_values, :uniforms, :vertex_shader, :fragment_shader
+    attr_accessor :map, :env_map, :light_map, :normal_map, :specular_map, :alpha_map, :combine, :vertex_colors, :fog,
+      :size_attenuation, :skinning, :morph_targets, :morph_normals, :metal, :wrap_around, :defines, :lights, :color, :bump_map,
+      :reflectivity, :refraction_ratio, :wireframe, :default_attribute_values, :uniforms, :vertex_shader, :fragment_shader
 
     def initialize
       super

--- a/lib/mittsu/materials/material.rb
+++ b/lib/mittsu/materials/material.rb
@@ -1,5 +1,4 @@
 require 'securerandom'
-require 'mittsu'
 
 module Mittsu
   class Material

--- a/lib/mittsu/math/box2.rb
+++ b/lib/mittsu/math/box2.rb
@@ -1,5 +1,3 @@
-require 'mittsu/math'
-
 module Mittsu
   class Box2
     attr_accessor :min, :max

--- a/lib/mittsu/math/box3.rb
+++ b/lib/mittsu/math/box3.rb
@@ -1,5 +1,3 @@
-require 'mittsu/math'
-
 module Mittsu
   class Box3
     attr_accessor :min, :max

--- a/lib/mittsu/math/color.rb
+++ b/lib/mittsu/math/color.rb
@@ -1,4 +1,3 @@
-require 'mittsu/math'
 require 'mittsu/math/vector3'
 
 module Mittsu

--- a/lib/mittsu/math/euler.rb
+++ b/lib/mittsu/math/euler.rb
@@ -7,7 +7,7 @@ module Mittsu
 
     def initialize(x = 0.0, y = 0.0, z = 0.0, order = DefaultOrder)
       @x, @y, @z, @order = x.to_f, y.to_f, z.to_f, order
-      @on_change_callback = false
+      @on_change_callback = nil
     end
 
     def set(x, y, z, order = nil)

--- a/lib/mittsu/math/euler.rb
+++ b/lib/mittsu/math/euler.rb
@@ -1,5 +1,3 @@
-require 'mittsu/math'
-
 module Mittsu
   class Euler
     RotationOrders = [ 'XYZ', 'YZX', 'ZXY', 'XZY', 'YXZ', 'ZYX' ]
@@ -9,6 +7,7 @@ module Mittsu
 
     def initialize(x = 0.0, y = 0.0, z = 0.0, order = DefaultOrder)
       @x, @y, @z, @order = x.to_f, y.to_f, z.to_f, order
+      @on_change_callback = false
     end
 
     def set(x, y, z, order = nil)

--- a/lib/mittsu/math/frustum.rb
+++ b/lib/mittsu/math/frustum.rb
@@ -1,5 +1,3 @@
-require 'mittsu/math'
-
 module Mittsu
   class Frustum
     attr_accessor :planes

--- a/lib/mittsu/math/line3.rb
+++ b/lib/mittsu/math/line3.rb
@@ -1,5 +1,3 @@
-require 'mittsu/math'
-
 module Mittsu
   class Line3
     attr_accessor :start_point, :end_point

--- a/lib/mittsu/math/matrix3.rb
+++ b/lib/mittsu/math/matrix3.rb
@@ -1,5 +1,3 @@
-require 'mittsu/math'
-
 module Mittsu
   class Matrix3
     attr_accessor :elements

--- a/lib/mittsu/math/matrix4.rb
+++ b/lib/mittsu/math/matrix4.rb
@@ -1,5 +1,3 @@
-require 'mittsu/math'
-
 module Mittsu
   class Matrix4
     attr_accessor :elements

--- a/lib/mittsu/math/plane.rb
+++ b/lib/mittsu/math/plane.rb
@@ -1,5 +1,3 @@
-require 'mittsu/math'
-
 module Mittsu
   class Plane
     attr_accessor :normal, :constant

--- a/lib/mittsu/math/quaternion.rb
+++ b/lib/mittsu/math/quaternion.rb
@@ -6,7 +6,7 @@ module Mittsu
 
     def initialize(x = 0.0, y = 0.0, z = 0.0, w = 1.0)
       @x, @y, @z, @w = x, y, z, w
-      @on_change_callback = false
+      @on_change_callback = nil
     end
 
     def set(x, y, z, w)

--- a/lib/mittsu/math/quaternion.rb
+++ b/lib/mittsu/math/quaternion.rb
@@ -1,5 +1,3 @@
-require 'mittsu/math'
-
 module Mittsu
   class Quaternion
     EPS = 0.000001
@@ -8,6 +6,7 @@ module Mittsu
 
     def initialize(x = 0.0, y = 0.0, z = 0.0, w = 1.0)
       @x, @y, @z, @w = x, y, z, w
+      @on_change_callback = false
     end
 
     def set(x, y, z, w)
@@ -304,6 +303,5 @@ module Mittsu
     def self.slerp(qa, qb, qm, t)
       qm.copy(qa).slerp(qb, t)
     end
-
   end
 end

--- a/lib/mittsu/math/ray.rb
+++ b/lib/mittsu/math/ray.rb
@@ -1,5 +1,3 @@
-require 'mittsu/math'
-
 module Mittsu
   class Ray
     attr_accessor :origin, :direction

--- a/lib/mittsu/math/sphere.rb
+++ b/lib/mittsu/math/sphere.rb
@@ -1,5 +1,3 @@
-require 'mittsu/math'
-
 module Mittsu
   class Sphere
     attr_accessor :center, :radius

--- a/lib/mittsu/math/spline.rb
+++ b/lib/mittsu/math/spline.rb
@@ -1,5 +1,3 @@
-require 'mittsu/math'
-
 module Mittsu
   class Spline
     Point = Struct.new(:x, :y, :z)

--- a/lib/mittsu/math/triangle.rb
+++ b/lib/mittsu/math/triangle.rb
@@ -1,5 +1,3 @@
-require 'mittsu/math'
-
 module Mittsu
   class Triangle
     attr_accessor :a, :b, :c

--- a/lib/mittsu/math/vector2.rb
+++ b/lib/mittsu/math/vector2.rb
@@ -1,4 +1,3 @@
-require 'mittsu/math'
 require 'mittsu/math/vector'
 
 module Mittsu

--- a/lib/mittsu/math/vector3.rb
+++ b/lib/mittsu/math/vector3.rb
@@ -1,4 +1,3 @@
-require 'mittsu/math'
 require 'mittsu/math/vector'
 
 module Mittsu

--- a/lib/mittsu/math/vector4.rb
+++ b/lib/mittsu/math/vector4.rb
@@ -1,4 +1,3 @@
-require 'mittsu/math'
 require 'mittsu/math/vector'
 
 module Mittsu

--- a/lib/mittsu/objects/line.rb
+++ b/lib/mittsu/objects/line.rb
@@ -54,7 +54,6 @@ module Mittsu
           offsets.each_with_index do |offset, oi|
             start = offset[:start]
             count = offset[:count]
-            index = offset[:index]
 
             (start...(count-1)).step(step).each do |i|
               v_start.from_array(positions, a * 3)

--- a/lib/mittsu/renderers/glfw_window.rb
+++ b/lib/mittsu/renderers/glfw_window.rb
@@ -1,7 +1,7 @@
 require 'opengl'
 require 'glfw'
 
-require 'mittsu'
+require 'mittsu/utils'
 require 'mittsu/renderers/glfw_lib'
 glfw_lib = Mittsu::GLFWLib.discover
 GLFW.load_lib(ENV["MITTSU_LIBGLFW_FILE"] || glfw_lib.file, ENV["MITTSU_LIBGLFW_PATH"] || glfw_lib.path) unless Mittsu.test?

--- a/lib/mittsu/renderers/opengl/core/object_3d.rb
+++ b/lib/mittsu/renderers/opengl/core/object_3d.rb
@@ -1,6 +1,6 @@
 module Mittsu
   class Object3D
-    attr_accessor :morph_target_influences, :renderer
+    attr_accessor :morph_target_influences, :renderer, :initted
     attr_reader :model_view_matrix
     attr_writer :active
 

--- a/lib/mittsu/renderers/opengl/opengl_geometry_group.rb
+++ b/lib/mittsu/renderers/opengl/opengl_geometry_group.rb
@@ -20,6 +20,7 @@ module Mittsu
       @num_morph_normals = num_morph_normals
 
       @renderer = renderer
+      @custom_attributes_list = []
     end
 
     def create_mesh_buffers

--- a/lib/mittsu/renderers/opengl/opengl_program.rb
+++ b/lib/mittsu/renderers/opengl/opengl_program.rb
@@ -1,10 +1,9 @@
 require 'erb'
-
 require 'mittsu/renderers/opengl/opengl_shader'
 
 module Mittsu
   class OpenGLProgram
-    attr_reader :id, :program, :uniforms, :attributes
+    attr_reader :id, :program, :uniforms
     attr_accessor :code, :used_times, :attributes, :vertex_shader, :fragment_shader
 
     def initialize(renderer, code, material, parameters)

--- a/lib/mittsu/renderers/opengl_renderer.rb
+++ b/lib/mittsu/renderers/opengl_renderer.rb
@@ -7,7 +7,6 @@ require 'mittsu/renderers/opengl/opengl_lib'
 opengl_lib = Mittsu::OpenGLLib.discover
 OpenGL.load_lib(ENV["MITTSU_LIBGL_FILE"] || opengl_lib.file, ENV["MITTSU_LIBGL_PATH"] || opengl_lib.path)
 
-require 'mittsu'
 require 'mittsu/renderers/glfw_window'
 require 'mittsu/renderers/opengl/opengl_implementations'
 require 'mittsu/renderers/opengl/opengl_debug'

--- a/lib/mittsu/renderers/opengl_renderer.rb
+++ b/lib/mittsu/renderers/opengl_renderer.rb
@@ -2,7 +2,6 @@ require 'opengl'
 require 'glfw'
 require 'fiddle'
 
-
 require 'mittsu/renderers/opengl/opengl_lib'
 opengl_lib = Mittsu::OpenGLLib.discover
 OpenGL.load_lib(ENV["MITTSU_LIBGL_FILE"] || opengl_lib.file, ENV["MITTSU_LIBGL_PATH"] || opengl_lib.path)
@@ -29,9 +28,11 @@ require 'mittsu/renderers/opengl/opengl_mittsu_params'
 
 module Mittsu
   class OpenGLRenderer
-    attr_accessor :auto_clear, :auto_clear_color, :auto_clear_depth, :auto_clear_stencil, :sort_objects, :gamma_factor, :gamma_input, :gamma_output, :shadow_map_enabled, :shadow_map_type, :shadow_map_cull_face, :shadow_map_debug, :shadow_map_cascade, :max_morph_targets, :max_morph_normals, :info, :pixel_ratio, :window, :width, :height, :state
+    attr_accessor :auto_clear, :auto_clear_color, :auto_clear_depth, :auto_clear_stencil, :sort_objects, :gamma_factor, :gamma_input,
+      :gamma_output, :shadow_map_enabled, :shadow_map_type, :shadow_map_cull_face, :shadow_map_debug, :shadow_map_cascade,
+      :max_morph_targets, :max_morph_normals, :info, :pixel_ratio, :window, :width, :height, :state
 
-    attr_reader :logarithmic_depth_buffer, :max_morph_targets, :max_morph_normals, :shadow_map_type, :shadow_map_debug, :shadow_map_cascade, :programs, :light_renderer, :proj_screen_matrix
+    attr_reader :logarithmic_depth_buffer, :programs, :light_renderer, :proj_screen_matrix
 
     def initialize(parameters = {})
       puts "OpenGLRenderer (Revision #{REVISION})"
@@ -80,11 +81,6 @@ module Mittsu
 
     # TODO: get_context ???
     # TODO: force_context_loss ???
-
-    def supports_vertex_textures?
-      @_supports_vertex_textures
-    end
-
     # TODO: supports_float_textures? ???
     # TODO: supports[half|standard|compressed|blend min max] ... ???
 

--- a/lib/mittsu/scenes/scene.rb
+++ b/lib/mittsu/scenes/scene.rb
@@ -1,5 +1,3 @@
-require 'mittsu'
-
 module Mittsu
   class Scene < Object3D
 

--- a/lib/mittsu/textures/texture.rb
+++ b/lib/mittsu/textures/texture.rb
@@ -10,9 +10,10 @@ module Mittsu
     DEFAULT_IMAGE = nil
     DEFAULT_MAPPING = UVMapping
 
-    attr_reader :id, :uuid, :type
+    attr_reader :id, :uuid
 
-    attr_accessor :image, :name, :source_file, :mipmaps, :offset, :repeat, :generate_mipmaps, :premultiply_alpha, :filp_y, :unpack_alignment, :on_update, :mipmaps, :mapping, :wrap_s, :wrap_t, :mag_filter, :min_filter, :anisotropy, :format, :type
+    attr_accessor :image, :name, :source_file, :mipmaps, :offset, :repeat, :generate_mipmaps, :premultiply_alpha, :filp_y,
+      :unpack_alignment, :on_update, :mapping, :wrap_s, :wrap_t, :mag_filter, :min_filter, :anisotropy, :format, :type
 
     def initialize(image = DEFAULT_IMAGE, mapping = DEFAULT_MAPPING, wrap_s = ClampToEdgeWrapping, wrap_t = ClampToEdgeWrapping, mag_filter = LinearFilter, min_filter = LinearMipMapLinearFilter, format = RGBAFormat, type = UnsignedByteType, anisotropy = 1)
       super()
@@ -42,6 +43,7 @@ module Mittsu
 
       @_needs_update = false
       @on_update = nil
+      @_listeners = {}
     end
 
     def needs_update?

--- a/lib/mittsu/utils.rb
+++ b/lib/mittsu/utils.rb
@@ -1,0 +1,15 @@
+module Mittsu
+  DEBUG = ENV["DEBUG"] == "true"
+
+  def self.debug?
+    DEBUG
+  end
+
+  def self.env
+    ENV["MITTSU_ENV"]
+  end
+
+  def self.test?
+    env == 'test'
+  end
+end

--- a/mittsu.gemspec
+++ b/mittsu.gemspec
@@ -23,15 +23,15 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.0.0'
   spec.requirements << 'OpenGL 3.3+ capable hardware and drivers'
 
-  spec.add_runtime_dependency 'opengl-bindings', "~> 1.5"
-  spec.add_runtime_dependency 'ffi', "~> 1.9"
-  spec.add_runtime_dependency 'chunky_png', "~> 1.3"
+  spec.add_runtime_dependency 'opengl-bindings'
+  spec.add_runtime_dependency 'ffi'
+  spec.add_runtime_dependency 'chunky_png'
 
-  spec.add_development_dependency "bundler", "~> 1.9"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency 'minitest', '~> 5.7'
-  spec.add_development_dependency 'minitest-reporters', '~> 1.1'
-  spec.add_development_dependency 'pry', '~> 0.10'
-  spec.add_development_dependency 'benchmark-ips', '~> 2.3'
-  spec.add_development_dependency 'simplecov', '~> 0.17'
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency 'minitest'
+  spec.add_development_dependency 'minitest-reporters'
+  spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'benchmark-ips'
+  spec.add_development_dependency 'simplecov'
 end


### PR DESCRIPTION
I've been trying to tackle the screenshot issue, but it turned out that mittsu doesn't work on the latest Ruby version due to some restrictions in the dependencies, so I had to meddle with some things to even run it (I'm still not finished with the screenshots, as in I still need to work out from where to properly get the pixels, but that's another story).

Meanwhile, this is the PR that lessens the gem's dependencies and makes it possible to run on Ruby versions from 2.3.x to 2.6.x. All these versions pass all the tests - I've included a TravisCI config that has the testing matrix for that.

Additionally, the newer version of the `rake` gem showed up a ton of warnings by default about circular requires and uninitialized instance variables, which make up for the bulk of this PR. There's still some left, but these are only the ones that are not immediately obvious on how to fix them.

I've supressed the warnings anyway, because it's mostly annoying, but I can try to get rid of the rest of them if needed.

Edit: I see Code Climate complains - two of these complains ("similar blocks of code, consider refactoring") are why I stopped using it myself. Yeah, they're similar, they're both `attr_accessor` and they both have the same number of arguments.