### PR TITLE
Enable AA (AntiAliasing) Support

### DIFF
--- a/lib/mittsu/renderers/glfw_window.rb
+++ b/lib/mittsu/renderers/glfw_window.rb
@@ -13,7 +13,7 @@ module Mittsu
     class Window
       attr_accessor :key_press_handler, :key_release_handler, :key_repeat_handler, :char_input_handler, :cursor_pos_handler, :mouse_button_press_handler, :mouse_button_release_handler, :scroll_handler, :framebuffer_size_handler
 
-      def initialize(width, height, title, antialias)
+      def initialize(width, height, title, antialias: 0)
         glfwInit
 
         glfwWindowHint GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE

--- a/lib/mittsu/renderers/glfw_window.rb
+++ b/lib/mittsu/renderers/glfw_window.rb
@@ -13,7 +13,7 @@ module Mittsu
     class Window
       attr_accessor :key_press_handler, :key_release_handler, :key_repeat_handler, :char_input_handler, :cursor_pos_handler, :mouse_button_press_handler, :mouse_button_release_handler, :scroll_handler, :framebuffer_size_handler
 
-      def initialize(width, height, title)
+      def initialize(width, height, title, antialias)
         glfwInit
 
         glfwWindowHint GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE
@@ -21,6 +21,10 @@ module Mittsu
         glfwWindowHint GLFW_CONTEXT_VERSION_MAJOR, 3
         glfwWindowHint GLFW_CONTEXT_VERSION_MINOR, 3
         glfwWindowHint GLFW_CONTEXT_REVISION, 0
+
+        if antialias > 0
+          glfwWindowHint GLFW_SAMPLES, antialias
+        end
 
         @width, @height, @title = width, height, title
         @handle = glfwCreateWindow(@width, @height, @title, nil, nil)

--- a/lib/mittsu/renderers/opengl_renderer.rb
+++ b/lib/mittsu/renderers/opengl_renderer.rb
@@ -974,7 +974,7 @@ module Mittsu
       #   preserve_drawing_buffer: _preserve_drawing_buffer
       # }
 
-      @window = GLFW::Window.new(@width, @height, @title, @antialias)
+      @window = GLFW::Window.new(@width, @height, @title, antialias: @antialias)
 
       default_target.set_viewport_size(*(@window.framebuffer_size))
 

--- a/lib/mittsu/renderers/opengl_renderer.rb
+++ b/lib/mittsu/renderers/opengl_renderer.rb
@@ -935,7 +935,6 @@ module Mittsu
       @_alpha = parameters.fetch(:alpha, false)
       @_depth = parameters.fetch(:depth, true)
       @_stencil = parameters.fetch(:stencil, true)
-      @_antialias = parameters.fetch(:antialias, false)
       @_premultiplied_alpha = parameters.fetch(:premultiplied_alpha, true)
       @_preserve_drawing_buffer = parameters.fetch(:preserve_drawing_buffer, false)
       @logarithmic_depth_buffer = parameters.fetch(:logarithmic_depth_buffer, false)
@@ -943,6 +942,7 @@ module Mittsu
       @width = parameters.fetch(:width, 800)
       @height = parameters.fetch(:height, 600)
       @title = parameters.fetch(:title, "Mittsu #{REVISION}")
+      @antialias = parameters.fetch(:antialias, 0)
     end
 
     def get_gpu_capabilities
@@ -974,7 +974,7 @@ module Mittsu
       #   preserve_drawing_buffer: _preserve_drawing_buffer
       # }
 
-      @window = GLFW::Window.new(@width, @height, @title)
+      @window = GLFW::Window.new(@width, @height, @title, @antialias)
 
       default_target.set_viewport_size(*(@window.framebuffer_size))
 

--- a/test/support/glfw_window_stub.rb
+++ b/test/support/glfw_window_stub.rb
@@ -5,7 +5,7 @@ module Mittsu
     class Window
       attr_accessor :key_press_handler, :key_release_handler, :key_repeat_handler, :char_input_handler, :cursor_pos_handler, :mouse_button_press_handler, :mouse_button_release_handler, :scroll_handler, :framebuffer_size_handler
 
-      def initialize(width, height, title, antialias)
+      def initialize(width, height, title, antialias: 0)
         @width, @height, @title, @antialias = width, height, title, antialias
       end
 

--- a/test/support/glfw_window_stub.rb
+++ b/test/support/glfw_window_stub.rb
@@ -6,7 +6,7 @@ module Mittsu
       attr_accessor :key_press_handler, :key_release_handler, :key_repeat_handler, :char_input_handler, :cursor_pos_handler, :mouse_button_press_handler, :mouse_button_release_handler, :scroll_handler, :framebuffer_size_handler
 
       def initialize(width, height, title, antialias)
-        @width, @height, @title @antialias = width, height, title, antialias
+        @width, @height, @title, @antialias = width, height, title, antialias
       end
 
       def run

--- a/test/support/glfw_window_stub.rb
+++ b/test/support/glfw_window_stub.rb
@@ -5,8 +5,8 @@ module Mittsu
     class Window
       attr_accessor :key_press_handler, :key_release_handler, :key_repeat_handler, :char_input_handler, :cursor_pos_handler, :mouse_button_press_handler, :mouse_button_release_handler, :scroll_handler, :framebuffer_size_handler
 
-      def initialize(width, height, title)
-        @width, @height, @title = width, height, title
+      def initialize(width, height, title, antialias)
+        @width, @height, @title @antialias = width, height, title, antialias
       end
 
       def run


### PR DESCRIPTION
This allows the user to set `GLFW_SAMPLES` value  enabling AA. Implementation is backwards compatible and defaults to 0 samples (off).